### PR TITLE
Improve AI booking flow

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,0 +1,34 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const apiKey = process.env.API_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'OpenAI API key not set' });
+    return;
+  }
+
+  try {
+    const { messages, model = 'gpt-3.5-turbo' } = req.body || {};
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model, messages }),
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      res.status(response.status).json({ error: data.error?.message || 'API request failed' });
+      return;
+    }
+    res.status(200).json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}

--- a/dark_theme.css
+++ b/dark_theme.css
@@ -208,6 +208,17 @@
     margin-top: 6px;
   }
 
+  .clinic-options {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 8px;
+  }
+
+  .clinic-address {
+    color: #aaa;
+  }
+
   .consent-button {
     background: var(--button-bg);
     border: 1px solid var(--primary-color);

--- a/dark_theme.css
+++ b/dark_theme.css
@@ -197,6 +197,11 @@
     line-height: 1.5;
   }
 
+  .message-content img {
+    max-width: 160px;
+    border-radius: 8px;
+  }
+
   .button-row {
     display: flex;
     gap: 10px;

--- a/dark_theme.css
+++ b/dark_theme.css
@@ -219,6 +219,22 @@
     color: #aaa;
   }
 
+  .doctor-options {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 8px;
+  }
+
+  .doctor-desc {
+    font-size: 0.9rem;
+  }
+
+  .doctor-lang {
+    color: #aaa;
+    font-size: 0.85rem;
+  }
+
   .consent-button {
     background: var(--button-bg);
     border: 1px solid var(--primary-color);

--- a/dark_theme.css
+++ b/dark_theme.css
@@ -258,6 +258,15 @@
     background: var(--primary-light);
     transform: scale(1.05);
   }
+
+  .camera-button {
+    background: var(--primary-light);
+    margin-right: 8px;
+  }
+
+  .camera-button:hover {
+    background: var(--primary-color);
+  }
   
   /* Options Container Styling */
   .options-container {

--- a/dark_theme.css
+++ b/dark_theme.css
@@ -315,6 +315,22 @@
   .subtle-text {
     color: #aaa;
   }
+
+  .back-button {
+    background: none;
+    border: none;
+    font-size: 1.2rem;
+    cursor: pointer;
+    margin-bottom: 4px;
+  }
+
+  .close-card {
+    background: none;
+    border: none;
+    font-size: 1rem;
+    align-self: flex-end;
+    cursor: pointer;
+  }
   
   /* Options Container Styling */
   .options-container {

--- a/dark_theme.css
+++ b/dark_theme.css
@@ -265,12 +265,11 @@
   }
 
   .camera-button {
-    background: var(--primary-light);
     margin-right: 8px;
   }
 
   .camera-button:hover {
-    background: var(--primary-color);
+    background: var(--button-hover);
   }
   
   /* Options Container Styling */

--- a/dark_theme.css
+++ b/dark_theme.css
@@ -235,6 +235,19 @@
     font-size: 0.85rem;
   }
 
+  .slot-options {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 8px;
+  }
+
+  .slot-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
   .consent-button {
     background: var(--button-bg);
     border: 1px solid var(--primary-color);

--- a/dark_theme.css
+++ b/dark_theme.css
@@ -196,6 +196,26 @@
   .message-content {
     line-height: 1.5;
   }
+
+  .button-row {
+    display: flex;
+    gap: 10px;
+    margin-top: 6px;
+  }
+
+  .consent-button {
+    background: var(--button-bg);
+    border: 1px solid var(--primary-color);
+    border-radius: 8px;
+    padding: 8px 14px;
+    color: var(--primary-color);
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .consent-button:hover {
+    background: var(--button-hover);
+  }
   
   .chat-input-container {
     display: flex;

--- a/dark_theme.css
+++ b/dark_theme.css
@@ -311,6 +311,10 @@
   .camera-button:hover {
     background: var(--button-hover);
   }
+
+  .subtle-text {
+    color: #aaa;
+  }
   
   /* Options Container Styling */
   .options-container {

--- a/index.html
+++ b/index.html
@@ -42,6 +42,10 @@
                 </div>
 
                 <div class="chat-input-container">
+                    <input type="file" id="image-input" accept="image/*" capture="environment" style="display:none">
+                    <button id="camera-button" class="send-button camera-button">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h3l2-3h8l2 3h3a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
+                    </button>
                     <input type="text" id="user-input" placeholder="Type your message here..." class="chat-input">
                     <button id="send-button" class="send-button">
                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>

--- a/index.html
+++ b/index.html
@@ -43,9 +43,6 @@
 
                 <div class="chat-input-container">
                     <input type="file" id="image-input" accept="image/*" capture="environment" style="display:none">
-                    <button id="camera-button" class="send-button camera-button">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h3l2-3h8l2 3h3a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
-                    </button>
                     <input type="text" id="user-input" placeholder="Type your message here..." class="chat-input">
                     <button id="send-button" class="send-button">
                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>

--- a/script.js
+++ b/script.js
@@ -34,9 +34,13 @@ document.addEventListener("DOMContentLoaded", () => {
     awaitingZip: false,
     awaitingClinic: false,
     awaitingDoctor: false,
+    awaitingInsurance: false,
+    awaitingInsuranceOther: false,
     aiQuestions: 0,
     name: "",
     lastSymptom: "",
+    userLocation: "",
+    selectedInsurance: "",
     clarifying: false,
     clarifyIndex: 0,
     clarifyAnswers: [],
@@ -113,7 +117,8 @@ document.addEventListener("DOMContentLoaded", () => {
       bookings.forEach((b) => {
         const p = document.createElement("p");
         const clinicText = b.clinic ? ` at ${b.clinic.name}` : "";
-        p.innerHTML = `<strong>${b.doctor.name}</strong> (${b.doctor.specialty})${clinicText} - ${b.slot}`;
+        const insText = b.insurance ? ` with ${b.insurance}` : "";
+        p.innerHTML = `<strong>${b.doctor.name}</strong> (${b.doctor.specialty})${clinicText} - ${b.slot}${insText}`;
         div.appendChild(p);
       });
     } else {
@@ -269,9 +274,13 @@ document.addEventListener("DOMContentLoaded", () => {
     state.awaitingLocation = false;
     state.awaitingZip = false;
     state.awaitingClinic = false;
+    state.awaitingInsurance = false;
+    state.awaitingInsuranceOther = false;
     state.selectedDoctor = null;
     state.selectedSlot = null;
     state.selectedClinic = null;
+    state.selectedInsurance = '';
+    state.userLocation = '';
     state.aiQuestions = 0;
     state.name = "";
     state.lastSymptom = "";
@@ -363,6 +372,7 @@ document.addEventListener("DOMContentLoaded", () => {
       navigator.geolocation.getCurrentPosition(
         (pos) => {
           const loc = `${pos.coords.latitude.toFixed(3)},${pos.coords.longitude.toFixed(3)}`;
+          state.userLocation = loc;
           fetchClinics(loc);
         },
         () => {
@@ -428,9 +438,44 @@ document.addEventListener("DOMContentLoaded", () => {
     return spec.endsWith('s') ? spec : spec + 's';
   }
 
+  async function fetchInsuranceOptions(locationText) {
+    const messages = [
+      {
+        role: 'user',
+        content: `List up to 5 popular health insurance providers in ${locationText}. Respond ONLY with JSON ["A","B"]`,
+      },
+    ];
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-3.5-turbo', messages }),
+      });
+      const data = await response.json();
+      let opts = [];
+      if (response.ok) {
+        let content = data.choices?.[0]?.message?.content?.trim();
+        if (content) {
+          content = content.replace(/```json|```/g, '').trim();
+          try {
+            opts = JSON.parse(content);
+          } catch {}
+        }
+      }
+      if (!Array.isArray(opts) || !opts.length) {
+        opts = ['Insurance A', 'Insurance B', 'Insurance C'];
+      }
+      return opts.slice(0, 5);
+    } catch (err) {
+      console.error(err);
+      return ['Insurance A', 'Insurance B', 'Insurance C'];
+    }
+  }
+
   let clinicMessage = null;
   let doctorMessage = null;
   let clinicsData = [];
+  let insuranceOptions = [];
 
   function showClinicOptions(clinics) {
     clinicsData = clinics;
@@ -547,7 +592,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const btn = document.createElement('button');
       btn.className = 'glass-button select-doctor';
       btn.textContent = 'Select';
-      btn.addEventListener('click', () => selectDoctor(d));
+      btn.addEventListener('click', () => expandDoctorCard(card, d));
       card.appendChild(btn);
       container.appendChild(card);
     });
@@ -571,50 +616,105 @@ document.addEventListener("DOMContentLoaded", () => {
     doctorMessage = msg;
   }
 
-  function selectDoctor(doc) {
+  function expandDoctorCard(card, doc) {
     state.selectedDoctor = doc;
     state.awaitingDoctor = false;
-    if (doctorMessage) { doctorMessage.remove(); doctorMessage = null; }
-    showAppointmentOptions(doc);
-  }
-
-  function showAppointmentOptions(doctor) {
-    optionsContainer.innerHTML = "";
-    if (!appointmentTemplate) return;
-    const content = appointmentTemplate.content.cloneNode(true);
-    content.querySelector(".doctor-name").textContent = doctor.name;
-    const slotList = content.querySelector(".slot-list");
-    doctor.slots.forEach((time) => {
-      const btn = document.createElement("button");
-      btn.className = "glass-button select-slot";
-      btn.textContent = time;
-      btn.addEventListener("click", () => selectSlot(time));
-      slotList.appendChild(btn);
+    const selectBtn = card.querySelector('.select-doctor');
+    if (selectBtn) selectBtn.remove();
+    const slotsDiv = document.createElement('div');
+    slotsDiv.className = 'slot-options';
+    doc.slots.forEach((time) => {
+      const row = document.createElement('div');
+      row.className = 'slot-row';
+      const span = document.createElement('span');
+      span.textContent = time;
+      const book = document.createElement('button');
+      book.className = 'glass-button book-slot';
+      book.textContent = 'Book';
+      book.addEventListener('click', () => selectSlot(time, doc));
+      row.appendChild(span);
+      row.appendChild(book);
+      slotsDiv.appendChild(row);
     });
-    optionsContainer.appendChild(content);
-    optionsContainer.classList.add("active");
-    state.waitingForSlot = true;
+    card.appendChild(slotsDiv);
   }
 
-  function selectSlot(time) {
-    bookings.push({ doctor: state.selectedDoctor, clinic: state.selectedClinic, slot: time });
-    state.selectedSlot = time;
-    state.waitingForSlot = false;
-    optionsContainer.classList.remove("active");
-    addBotMessage(`Appointment with ${state.selectedDoctor.name} confirmed for ${time}. You'll receive a reminder!`);
+  async function askForInsurance() {
+    document.querySelectorAll('.button-row').forEach((el) => el.remove());
+    insuranceOptions = await fetchInsuranceOptions(state.userLocation || '');
+    addBotMessage(
+      `Which insurance will you use? Popular choices here: ${insuranceOptions.slice(0, 3).join(', ')}. Or Other.`
+    );
+    showInsuranceOptions();
+  }
+
+  function showInsuranceOptions() {
+    const row = document.createElement('div');
+    row.className = 'button-row';
+    insuranceOptions.forEach((ins) => {
+      const btn = document.createElement('button');
+      btn.className = 'consent-button';
+      btn.textContent = ins;
+      btn.addEventListener('click', () => {
+        row.remove();
+        selectInsurance(ins);
+      });
+      row.appendChild(btn);
+    });
+    const other = document.createElement('button');
+    other.className = 'consent-button';
+    other.textContent = 'Other';
+    other.addEventListener('click', () => {
+      row.remove();
+      state.awaitingInsurance = false;
+      state.awaitingInsuranceOther = true;
+      addBotMessage('Please type your insurer name.');
+    });
+    row.appendChild(other);
+    chatMessages.appendChild(row);
+    scrollToBottom();
+    state.awaitingInsurance = true;
+  }
+
+  function selectInsurance(name) {
+    state.selectedInsurance = name;
+    state.awaitingInsurance = false;
+    finalizeBooking();
+  }
+
+  function finalizeBooking() {
+    bookings.push({
+      doctor: state.selectedDoctor,
+      clinic: state.selectedClinic,
+      slot: state.selectedSlot,
+      insurance: state.selectedInsurance,
+    });
+    addBotMessage(
+      `Appointment with ${state.selectedDoctor.name} confirmed for ${state.selectedSlot}. You'll receive a reminder!`
+    );
     updateSummary();
     state.waitingForSymptoms = true;
     state.selectedClinic = null;
     state.selectedDoctor = null;
     state.selectedSlot = null;
+    state.selectedInsurance = '';
     state.aiQuestions = 0;
     state.clarifying = false;
     state.clarifyIndex = 0;
     state.clarifyAnswers = [];
-    conversation = [{ role: "system", content: basePrompt }];
+    conversation = [{ role: 'system', content: basePrompt }];
     setTimeout(() => {
-      addBotMessage("Let me know if you have other symptoms.");
+      addBotMessage('Let me know if you have other symptoms.');
     }, 100);
+  }
+
+  // legacy doctor selection flow kept for reference
+
+  function selectSlot(time, doctor) {
+    state.selectedDoctor = doctor;
+    state.selectedSlot = time;
+    state.waitingForSlot = false;
+    askForInsurance();
   }
 
   async function handleUserMessage() {
@@ -644,6 +744,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (state.awaitingZip) {
       state.awaitingZip = false;
+      state.userLocation = message;
       fetchClinics(message);
       return;
     }
@@ -655,6 +756,18 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (state.awaitingDoctor) {
       addBotMessage('Please select one of the doctors below.');
+      return;
+    }
+
+    if (state.awaitingInsurance) {
+      addBotMessage('Please choose one of the insurance options below.');
+      return;
+    }
+
+    if (state.awaitingInsuranceOther) {
+      state.selectedInsurance = message;
+      state.awaitingInsuranceOther = false;
+      finalizeBooking();
       return;
     }
 
@@ -712,7 +825,7 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     } else if (state.waitingForSlot) {
       if (state.selectedDoctor.slots.includes(message)) {
-        selectSlot(message);
+        selectSlot(message, state.selectedDoctor);
       } else {
         addBotMessage("Please select an available time from the buttons below.");
       }

--- a/script.js
+++ b/script.js
@@ -87,6 +87,7 @@ document.addEventListener("DOMContentLoaded", () => {
     el.innerHTML = `<div class="message-content">${message}</div>`;
     chatMessages.appendChild(el);
     scrollToBottom();
+    return el;
   }
 
   function showAnalyzing() {
@@ -180,14 +181,15 @@ document.addEventListener("DOMContentLoaded", () => {
     row.appendChild(skip);
     chatMessages.appendChild(row);
     scrollToBottom();
+    imagePromptRow = row;
 
     cam.addEventListener('click', () => {
-      row.remove();
       imageInput.click();
     });
 
     skip.addEventListener('click', () => {
       row.remove();
+      imagePromptRow = null;
       addUserMessage('Skip');
       state.awaitingImage = false;
       state.clarifying = true;
@@ -353,7 +355,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function askForLocation() {
     document.querySelectorAll('.button-row').forEach((el) => el.remove());
-    addBotMessage(
+    const msg = addBotMessage(
       'May I use your device location to find the nearest clinic?<br>(If you\u2019d rather type your ZIP/postcode, choose Skip.)'
     );
     const row = document.createElement('div');
@@ -372,12 +374,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
     share.addEventListener('click', () => {
       row.remove();
+      msg.remove();
       state.awaitingLocation = false;
       navigator.geolocation.getCurrentPosition(
-        (pos) => {
+        async (pos) => {
           const loc = `${pos.coords.latitude.toFixed(3)},${pos.coords.longitude.toFixed(3)}`;
           state.userLocation = loc;
-          fetchClinics(loc);
+          const stop = showAnalyzing();
+          await fetchClinics(loc);
+          stop();
         },
         () => {
           addBotMessage("Couldn't get your location. Please type your ZIP/postcode.");
@@ -388,6 +393,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     skip.addEventListener('click', () => {
       row.remove();
+      msg.remove();
       addUserMessage('Skip');
       state.awaitingLocation = false;
       state.awaitingZip = true;
@@ -480,6 +486,8 @@ document.addEventListener("DOMContentLoaded", () => {
   let doctorMessage = null;
   let clinicsData = [];
   let insuranceOptions = [];
+  let expandedDoctorCard = null;
+  let imagePromptRow = null;
 
   function showClinicOptions(clinics) {
     clinicsData = clinics;
@@ -601,11 +609,9 @@ document.addEventListener("DOMContentLoaded", () => {
       container.appendChild(card);
     });
 
-    content.appendChild(intro);
-    content.appendChild(container);
     const back = document.createElement('button');
-    back.className = 'glass-button';
-    back.textContent = 'Back to clinics';
+    back.className = 'back-button';
+    back.textContent = '←';
     back.addEventListener('click', () => {
       msg.remove();
       state.awaitingDoctor = false;
@@ -613,6 +619,8 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     content.appendChild(back);
+    content.appendChild(intro);
+    content.appendChild(container);
     msg.appendChild(content);
     chatMessages.appendChild(msg);
     scrollToBottom();
@@ -621,6 +629,9 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function expandDoctorCard(card, doc) {
+    if (expandedDoctorCard && expandedDoctorCard !== card) {
+      collapseDoctorCard(expandedDoctorCard);
+    }
     state.selectedDoctor = doc;
     state.awaitingDoctor = false;
     const selectBtn = card.querySelector('.select-doctor');
@@ -640,7 +651,28 @@ document.addEventListener("DOMContentLoaded", () => {
       row.appendChild(book);
       slotsDiv.appendChild(row);
     });
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'close-card';
+    closeBtn.textContent = '✖';
+    closeBtn.addEventListener('click', () => collapseDoctorCard(card, doc));
+    card.prepend(closeBtn);
     card.appendChild(slotsDiv);
+    expandedDoctorCard = card;
+  }
+
+  function collapseDoctorCard(card, doc) {
+    const slots = card.querySelector('.slot-options');
+    if (slots) slots.remove();
+    const close = card.querySelector('.close-card');
+    if (close) close.remove();
+    if (!card.querySelector('.select-doctor')) {
+      const btn = document.createElement('button');
+      btn.className = 'glass-button select-doctor';
+      btn.textContent = 'Select';
+      btn.addEventListener('click', () => expandDoctorCard(card, doc));
+      card.appendChild(btn);
+    }
+    if (expandedDoctorCard === card) expandedDoctorCard = null;
   }
 
   async function askForInsurance() {
@@ -784,6 +816,10 @@ document.addEventListener("DOMContentLoaded", () => {
     state.selectedDoctor = doctor;
     state.selectedSlot = time;
     state.waitingForSlot = false;
+    if (doctorMessage) {
+      doctorMessage.remove();
+      doctorMessage = null;
+    }
     askForInsurance();
   }
 
@@ -914,7 +950,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function handleImageUpload(e) {
     const file = e.target.files[0];
-    if (file) analyzeImage(file);
+    if (file) {
+      if (imagePromptRow) {
+        imagePromptRow.remove();
+        imagePromptRow = null;
+      }
+      analyzeImage(file);
+    }
     e.target.value = "";
   }
 

--- a/script.js
+++ b/script.js
@@ -346,7 +346,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 type: "text",
                 text:
                   `A patient describes: ${state.lastSymptom}. ` +
-                  "Assess this skin photo and respond ONLY with JSON {\"diff\": [\"Diag1\", \"Diag2\", \"Diag3\"]}.",
+                  "Examine the skin photo and briefly describe in one or two sentences what you see. " +
+                  "Respond ONLY with JSON {\"desc\":\"short description\", \"diff\": [\"Diag1\", \"Diag2\", \"Diag3\"]}.",
               },
               { type: "image_url", image_url: { url: reader.result } },
             ],
@@ -359,16 +360,24 @@ document.addEventListener("DOMContentLoaded", () => {
         });
         const data = await response.json();
         let diag = "unsure";
+        let desc = "";
         if (response.ok) {
-          const content = data.choices?.[0]?.message?.content?.trim();
+          let content = data.choices?.[0]?.message?.content?.trim();
           if (content) {
+            // remove Markdown code fences
+            content = content.replace(/```json|```/g, "").trim();
             try {
               const parsed = JSON.parse(content);
               if (Array.isArray(parsed.diff) && parsed.diff.length) {
                 diag = parsed.diff[0];
               }
+              if (typeof parsed.desc === "string") {
+                desc = parsed.desc.trim();
+              }
             } catch {
-              diag = content.split(/[\.\n]/)[0];
+              const firstLine = content.split(/\n/)[0];
+              diag = firstLine.split(/[\.]/)[0];
+              desc = content;
             }
           }
         }
@@ -378,8 +387,9 @@ document.addEventListener("DOMContentLoaded", () => {
         state.selectedDoctor = derm;
         state.waitingForSymptoms = false;
         state.waitingForSlot = true;
+        const messageDesc = desc ? `${desc} ` : "";
         addBotMessage(
-          `Looks like ${diag} \u2014 but a dermatologist will give the final word. Let\u2019s book you in!`
+          `${messageDesc}Looks like ${diag} \u2014 but a dermatologist will give the final word. Let\u2019s book you in!`
         );
         showAppointmentOptions(state.selectedDoctor);
       } catch (err) {

--- a/script.js
+++ b/script.js
@@ -15,6 +15,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const chatMessages = document.getElementById("chat-messages");
   const userInput = document.getElementById("user-input");
   const sendButton = document.getElementById("send-button");
+  const cameraButton = document.getElementById("camera-button");
+  const imageInput = document.getElementById("image-input");
   const clearChatButton = document.getElementById("clear-chat");
   const optionsContainer = document.getElementById("options-container");
   const summary = document.getElementById("booking-summary");
@@ -22,11 +24,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const state = {
     awaitingConsent: true,
+    awaitingName: false,
+    awaitingImage: false,
     waitingForSymptoms: false,
     waitingForSlot: false,
     selectedDoctor: null,
     selectedSlot: null,
     aiQuestions: 0,
+    name: "",
+    lastSymptom: "",
   };
 
   const bookings = [];
@@ -88,9 +94,9 @@ document.addEventListener("DOMContentLoaded", () => {
     yes.addEventListener("click", () => {
       wrapper.remove();
       state.awaitingConsent = false;
-      state.waitingForSymptoms = true;
+      state.awaitingName = true;
       setTimeout(() => {
-        addBotMessage("Hello! What symptoms are you experiencing today?");
+        addBotMessage("Great! What's your name?");
       }, 100);
     });
 
@@ -106,11 +112,15 @@ document.addEventListener("DOMContentLoaded", () => {
     optionsContainer.innerHTML = "";
     optionsContainer.classList.remove("active");
     state.awaitingConsent = true;
+    state.awaitingName = false;
+    state.awaitingImage = false;
     state.waitingForSymptoms = false;
     state.waitingForSlot = false;
     state.selectedDoctor = null;
     state.selectedSlot = null;
     state.aiQuestions = 0;
+    state.name = "";
+    state.lastSymptom = "";
     conversation = [{ role: "system", content: basePrompt }];
     updateSummary();
     setTimeout(() => {
@@ -182,6 +192,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (message.toLowerCase() === "start") {
       state.awaitingConsent = true;
+      state.awaitingName = false;
+      state.awaitingImage = false;
       state.waitingForSymptoms = false;
       showConsentPrompt();
       return;
@@ -192,7 +204,41 @@ document.addEventListener("DOMContentLoaded", () => {
       return;
     }
 
+    if (state.awaitingName) {
+      state.name = message;
+      state.awaitingName = false;
+      state.waitingForSymptoms = true;
+      addBotMessage(`Hello ${state.name}. What symptoms are you experiencing?`);
+      return;
+    }
+
+    if (state.awaitingImage) {
+      if (message.toLowerCase() === "skip") {
+        state.awaitingImage = false;
+        const derm = DOCTORS.find((d) => d.specialty === "Dermatologist");
+        state.selectedDoctor = derm;
+        state.waitingForSymptoms = false;
+        state.waitingForSlot = true;
+        addBotMessage(
+          "Looks like eczema — but a dermatologist will give the final word. Let’s book you in!"
+        );
+        showAppointmentOptions(state.selectedDoctor);
+      } else {
+        addBotMessage("Please use the camera button or type skip.");
+      }
+      return;
+    }
+
     if (state.waitingForSymptoms) {
+      state.lastSymptom = message;
+      const dermWords = ["rash", "acne", "mole", "wound", "swelling", "cough"];
+      if (dermWords.some((w) => message.toLowerCase().includes(w))) {
+        state.awaitingImage = true;
+        addBotMessage(
+          "Could you snap a clear photo of the affected area? You can also type skip if you prefer."
+        );
+        return;
+      }
       try {
         const result = await getRecommendation(message);
         if (result.question && state.aiQuestions < 3) {
@@ -221,12 +267,74 @@ document.addEventListener("DOMContentLoaded", () => {
       } else {
         addBotMessage("Please select an available time from the buttons below.");
       }
-    } else {
-      addBotMessage("How else can I assist you?");
-    }
+  } else {
+    addBotMessage("How else can I assist you?");
+  }
+}
+
+  function handleImageUpload(e) {
+    const file = e.target.files[0];
+    if (file) analyzeImage(file);
+    e.target.value = "";
+  }
+
+  async function analyzeImage(file) {
+    const reader = new FileReader();
+    reader.onload = async () => {
+      try {
+        const messages = [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text:
+                  "Assess this skin photo and return JSON like {\"diff\":[\"Diag1\",\"Diag2\",\"Diag3\"]}.",
+              },
+              { type: "image_url", image_url: { url: reader.result } },
+            ],
+          },
+        ];
+        const response = await fetch("/api/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "gpt-4o", messages }),
+        });
+        const data = await response.json();
+        let diag = "eczema";
+        if (response.ok) {
+          try {
+            diag = JSON.parse(data.choices[0].message.content.trim()).diff[0];
+          } catch {}
+        }
+        state.awaitingImage = false;
+        const derm = DOCTORS.find((d) => d.specialty === "Dermatologist");
+        state.selectedDoctor = derm;
+        state.waitingForSymptoms = false;
+        state.waitingForSlot = true;
+        addBotMessage(
+          `Looks like ${diag} \u2014 but a dermatologist will give the final word. Let\u2019s book you in!`
+        );
+        showAppointmentOptions(state.selectedDoctor);
+      } catch (err) {
+        console.error(err);
+        state.awaitingImage = false;
+        addBotMessage(
+          "Error analyzing image. We'll book you with a dermatologist to be safe."
+        );
+        const derm = DOCTORS.find((d) => d.specialty === "Dermatologist");
+        state.selectedDoctor = derm;
+        state.waitingForSymptoms = false;
+        state.waitingForSlot = true;
+        showAppointmentOptions(state.selectedDoctor);
+      }
+    };
+    reader.readAsDataURL(file);
   }
 
   sendButton.addEventListener("click", handleUserMessage);
+  cameraButton.addEventListener("click", () => imageInput.click());
+  imageInput.addEventListener("change", handleImageUpload);
   userInput.addEventListener("keypress", (e) => {
     if (e.key === "Enter") handleUserMessage();
   });

--- a/script.js
+++ b/script.js
@@ -33,6 +33,7 @@ document.addEventListener("DOMContentLoaded", () => {
     awaitingLocation: false,
     awaitingZip: false,
     awaitingClinic: false,
+    awaitingDoctor: false,
     aiQuestions: 0,
     name: "",
     lastSymptom: "",
@@ -464,7 +465,96 @@ document.addEventListener("DOMContentLoaded", () => {
     state.selectedClinic = clinic;
     state.awaitingClinic = false;
     optionsContainer.classList.remove('active');
-    showAppointmentOptions(state.selectedDoctor);
+    fetchDoctors(clinic);
+  }
+
+  async function fetchDoctors(clinic) {
+    const spec = state.selectedDoctor.specialty;
+    const messages = [
+      {
+        role: 'user',
+        content:
+          `Generate 4 fictional ${spec}s working at ${clinic.name}. Return JSON ` +
+          `[{"name":"","desc":"","rating":0,"languages":[""],"slots":["time1","time2"]}] with at least 3 slots each.`,
+      },
+    ];
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-3.5-turbo', messages }),
+      });
+      const data = await response.json();
+      let docs = [];
+      if (response.ok) {
+        let content = data.choices?.[0]?.message?.content?.trim();
+        if (content) {
+          content = content.replace(/```json|```/g, '').trim();
+          try {
+            docs = JSON.parse(content);
+          } catch {}
+        }
+      }
+      if (!Array.isArray(docs) || !docs.length) {
+        docs = DOCTORS.filter((d) => d.specialty === spec).map((d) => ({
+          name: d.name,
+          desc: `${spec} with 5 years experience`,
+          rating: (4 + Math.random()).toFixed(1),
+          languages: ['English'],
+          slots: d.slots,
+        })).slice(0, 4);
+      }
+      showDoctorOptions(docs);
+    } catch (err) {
+      console.error(err);
+      const docs = DOCTORS.filter((d) => d.specialty === spec).map((d) => ({
+        name: d.name,
+        desc: `${spec} with 5 years experience`,
+        rating: (4 + Math.random()).toFixed(1),
+        languages: ['English'],
+        slots: d.slots,
+      })).slice(0, 4);
+      showDoctorOptions(docs);
+    }
+  }
+
+  function showDoctorOptions(doctors) {
+    const msg = document.createElement('div');
+    msg.className = 'message bot';
+    const content = document.createElement('div');
+    content.className = 'message-content';
+    const intro = document.createElement('p');
+    intro.textContent = `Doctors at ${state.selectedClinic.name}:`;
+    const container = document.createElement('div');
+    container.className = 'doctor-options';
+
+    doctors.forEach((d) => {
+      const card = document.createElement('div');
+      card.className = 'option-card doctor-card';
+      card.innerHTML =
+        `<div><strong>${d.name}</strong> ${d.rating}⭐</div>` +
+        `<div class="doctor-desc">${d.desc}</div>` +
+        `<div class="doctor-lang">Languages: ${d.languages.join(', ')}</div>`;
+      const btn = document.createElement('button');
+      btn.className = 'glass-button select-doctor';
+      btn.textContent = 'Select';
+      btn.addEventListener('click', () => selectDoctor(d));
+      card.appendChild(btn);
+      container.appendChild(card);
+    });
+
+    content.appendChild(intro);
+    content.appendChild(container);
+    msg.appendChild(content);
+    chatMessages.appendChild(msg);
+    scrollToBottom();
+    state.awaitingDoctor = true;
+  }
+
+  function selectDoctor(doc) {
+    state.selectedDoctor = doc;
+    state.awaitingDoctor = false;
+    showAppointmentOptions(doc);
   }
 
   function showAppointmentOptions(doctor) {
@@ -539,6 +629,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (state.awaitingClinic) {
       addBotMessage('Please choose one of the clinic options below.');
+      return;
+    }
+
+    if (state.awaitingDoctor) {
+      addBotMessage('Please select one of the doctors below.');
       return;
     }
 

--- a/script.js
+++ b/script.js
@@ -71,22 +71,22 @@ document.addEventListener("DOMContentLoaded", () => {
     addBotMessage(
       "\uD83D\uDC4B Welcome to HealthCo Clinics!<br>We\u2019ll use the info you share to find the best care for you.<br>Do you consent to proceeding under our privacy policy?"
     );
-    optionsContainer.innerHTML = "";
+    document.querySelectorAll('.button-row').forEach((el) => el.remove());
+    const wrapper = document.createElement("div");
+    wrapper.className = "button-row";
     const yes = document.createElement("button");
-    yes.className = "glass-button primary";
+    yes.className = "consent-button";
     yes.textContent = "Yes \u2705";
     const no = document.createElement("button");
-    no.className = "glass-button";
+    no.className = "consent-button";
     no.textContent = "No \u274C";
-    const wrapper = document.createElement("div");
     wrapper.appendChild(yes);
     wrapper.appendChild(no);
-    optionsContainer.appendChild(wrapper);
-    optionsContainer.classList.add("active");
+    chatMessages.appendChild(wrapper);
+    scrollToBottom();
 
     yes.addEventListener("click", () => {
-      optionsContainer.classList.remove("active");
-      optionsContainer.innerHTML = "";
+      wrapper.remove();
       state.awaitingConsent = false;
       state.waitingForSymptoms = true;
       setTimeout(() => {
@@ -95,8 +95,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     no.addEventListener("click", () => {
-      optionsContainer.classList.remove("active");
-      optionsContainer.innerHTML = "";
+      wrapper.remove();
       state.awaitingConsent = false;
       addBotMessage("No worries. If you change your mind, just type start.");
     });
@@ -189,7 +188,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     if (state.awaitingConsent) {
-      addBotMessage("Please use the buttons above to continue.");
+      addBotMessage("Please use the buttons below to continue.");
       return;
     }
 

--- a/script.js
+++ b/script.js
@@ -928,7 +928,25 @@ document.addEventListener("DOMContentLoaded", () => {
     userInput.placeholder = DEFAULT_PLACEHOLDER;
     setTimeout(() => {
       addBotMessage('Let me know if you want to make another booking.');
+      showBookAgainPrompt();
     }, 100);
+  }
+
+  function showBookAgainPrompt() {
+    document.querySelectorAll('.book-again-row').forEach((el) => el.remove());
+    const row = document.createElement('div');
+    row.className = 'button-row book-again-row';
+    const btn = document.createElement('button');
+    btn.className = 'consent-button';
+    btn.textContent = 'Book new appointment';
+    row.appendChild(btn);
+    chatMessages.appendChild(row);
+    scrollToBottom();
+    btn.addEventListener('click', () => {
+      row.remove();
+      addBotMessage(`Hello ${state.name || ''}. What symptoms are you experiencing?`);
+      state.waitingForSymptoms = true;
+    });
   }
 
   // legacy doctor selection flow kept for reference

--- a/script.js
+++ b/script.js
@@ -428,7 +428,13 @@ document.addEventListener("DOMContentLoaded", () => {
     return spec.endsWith('s') ? spec : spec + 's';
   }
 
+  let clinicMessage = null;
+  let doctorMessage = null;
+  let clinicsData = [];
+
   function showClinicOptions(clinics) {
+    clinicsData = clinics;
+    if (clinicMessage) clinicMessage.remove();
     const message = document.createElement('div');
     message.className = 'message bot';
     const content = document.createElement('div');
@@ -459,12 +465,14 @@ document.addEventListener("DOMContentLoaded", () => {
     chatMessages.appendChild(message);
     scrollToBottom();
     state.awaitingClinic = true;
+    clinicMessage = message;
   }
 
   function selectClinic(clinic) {
     state.selectedClinic = clinic;
     state.awaitingClinic = false;
     optionsContainer.classList.remove('active');
+    if (clinicMessage) { clinicMessage.remove(); clinicMessage = null; }
     fetchDoctors(clinic);
   }
 
@@ -519,6 +527,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function showDoctorOptions(doctors) {
+    if (doctorMessage) doctorMessage.remove();
     const msg = document.createElement('div');
     msg.className = 'message bot';
     const content = document.createElement('div');
@@ -545,15 +554,27 @@ document.addEventListener("DOMContentLoaded", () => {
 
     content.appendChild(intro);
     content.appendChild(container);
+    const back = document.createElement('button');
+    back.className = 'glass-button';
+    back.textContent = 'Back to clinics';
+    back.addEventListener('click', () => {
+      msg.remove();
+      state.awaitingDoctor = false;
+      showClinicOptions(clinicsData);
+    });
+
+    content.appendChild(back);
     msg.appendChild(content);
     chatMessages.appendChild(msg);
     scrollToBottom();
     state.awaitingDoctor = true;
+    doctorMessage = msg;
   }
 
   function selectDoctor(doc) {
     state.selectedDoctor = doc;
     state.awaitingDoctor = false;
+    if (doctorMessage) { doctorMessage.remove(); doctorMessage = null; }
     showAppointmentOptions(doc);
   }
 

--- a/script.js
+++ b/script.js
@@ -32,9 +32,18 @@ document.addEventListener("DOMContentLoaded", () => {
     aiQuestions: 0,
     name: "",
     lastSymptom: "",
+    clarifying: false,
+    clarifyIndex: 0,
+    clarifyAnswers: [],
   };
 
   const bookings = [];
+
+  const CLARIFY_QUESTIONS = [
+    "How long have you had this issue?",
+    "Does it itch or cause pain?",
+    "Have you noticed any triggers or tried treatments?",
+  ];
 
   function addUserMessage(message) {
     const el = document.createElement("div");
@@ -165,14 +174,83 @@ document.addEventListener("DOMContentLoaded", () => {
     skip.addEventListener('click', () => {
       row.remove();
       addUserMessage('Skip');
+      state.awaitingImage = false;
+      state.clarifying = true;
+      state.clarifyIndex = 0;
+      state.clarifyAnswers = [];
+      askNextClarifyQuestion();
+    });
+  }
+
+  function askNextClarifyQuestion() {
+    if (state.clarifyIndex < CLARIFY_QUESTIONS.length) {
+      const q = CLARIFY_QUESTIONS[state.clarifyIndex];
+      state.clarifyIndex++;
+      addBotMessage(q);
+    } else {
+      finalizeClarification();
+    }
+  }
+
+  async function finalizeClarification() {
+    state.clarifying = false;
+    try {
+      const diag = await getDiagnosisFromClarifications(
+        state.lastSymptom,
+        state.clarifyAnswers
+      );
       const derm = DOCTORS.find((d) => d.specialty === 'Dermatologist');
       state.selectedDoctor = derm;
-      state.awaitingImage = false;
       state.waitingForSymptoms = false;
       state.waitingForSlot = true;
-      addBotMessage("A dermatologist will give the final word. Let’s book you in!");
+      addBotMessage(
+        `Looks like ${diag} \u2014 but a dermatologist will give the final word. Let\u2019s book you in!`
+      );
       showAppointmentOptions(state.selectedDoctor);
+    } catch (err) {
+      console.error(err);
+      const derm = DOCTORS.find((d) => d.specialty === 'Dermatologist');
+      state.selectedDoctor = derm;
+      state.waitingForSymptoms = false;
+      state.waitingForSlot = true;
+      addBotMessage(
+        "A dermatologist will give the final word. Let’s book you in!"
+      );
+      showAppointmentOptions(state.selectedDoctor);
+    }
+  }
+
+  async function getDiagnosisFromClarifications(symptom, answers) {
+    const text = `Symptom: ${symptom}. Answers: ${answers
+      .map((a, i) => `Q${i + 1}: ${CLARIFY_QUESTIONS[i]} A: ${a}`)
+      .join(' ')}`;
+    const messages = [
+      {
+        role: 'user',
+        content:
+          text +
+          ' Based on this, what is the most likely skin diagnosis? Respond with JSON {"diagnosis":"text"}.',
+      },
+    ];
+    const response = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-3.5-turbo', messages }),
     });
+    const data = await response.json();
+    if (response.ok) {
+      let content = data.choices?.[0]?.message?.content?.trim();
+      if (content) {
+        content = content.replace(/```json|```/g, '').trim();
+        try {
+          const parsed = JSON.parse(content);
+          if (parsed.diagnosis) return parsed.diagnosis;
+        } catch {
+          return content.split(/\n/)[0];
+        }
+      }
+    }
+    throw new Error('diagnosis fetch failed');
   }
 
   function clearChat() {
@@ -189,6 +267,9 @@ document.addEventListener("DOMContentLoaded", () => {
     state.aiQuestions = 0;
     state.name = "";
     state.lastSymptom = "";
+    state.clarifying = false;
+    state.clarifyIndex = 0;
+    state.clarifyAnswers = [];
     conversation = [{ role: "system", content: basePrompt }];
     updateSummary();
     setTimeout(() => {
@@ -246,6 +327,9 @@ document.addEventListener("DOMContentLoaded", () => {
     state.selectedDoctor = null;
     state.selectedSlot = null;
     state.aiQuestions = 0;
+    state.clarifying = false;
+    state.clarifyIndex = 0;
+    state.clarifyAnswers = [];
     conversation = [{ role: "system", content: basePrompt }];
     setTimeout(() => {
       addBotMessage("Let me know if you have other symptoms.");
@@ -282,6 +366,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (state.awaitingImage) {
       addBotMessage("Please use the buttons below to upload a photo or skip.");
+      return;
+    }
+
+    if (state.clarifying) {
+      state.clarifyAnswers.push(message);
+      askNextClarifyQuestion();
       return;
     }
 

--- a/script.js
+++ b/script.js
@@ -21,7 +21,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const appointmentTemplate = document.getElementById("appointment-options-template");
 
   const state = {
-    waitingForSymptoms: true,
+    awaitingConsent: true,
+    waitingForSymptoms: false,
     waitingForSlot: false,
     selectedDoctor: null,
     selectedSlot: null,
@@ -66,11 +67,47 @@ document.addEventListener("DOMContentLoaded", () => {
     summary.appendChild(div);
   }
 
+  function showConsentPrompt() {
+    addBotMessage(
+      "\uD83D\uDC4B Welcome to HealthCo Clinics!<br>We\u2019ll use the info you share to find the best care for you.<br>Do you consent to proceeding under our privacy policy?"
+    );
+    optionsContainer.innerHTML = "";
+    const yes = document.createElement("button");
+    yes.className = "glass-button primary";
+    yes.textContent = "Yes \u2705";
+    const no = document.createElement("button");
+    no.className = "glass-button";
+    no.textContent = "No \u274C";
+    const wrapper = document.createElement("div");
+    wrapper.appendChild(yes);
+    wrapper.appendChild(no);
+    optionsContainer.appendChild(wrapper);
+    optionsContainer.classList.add("active");
+
+    yes.addEventListener("click", () => {
+      optionsContainer.classList.remove("active");
+      optionsContainer.innerHTML = "";
+      state.awaitingConsent = false;
+      state.waitingForSymptoms = true;
+      setTimeout(() => {
+        addBotMessage("Hello! What symptoms are you experiencing today?");
+      }, 100);
+    });
+
+    no.addEventListener("click", () => {
+      optionsContainer.classList.remove("active");
+      optionsContainer.innerHTML = "";
+      state.awaitingConsent = false;
+      addBotMessage("No worries. If you change your mind, just type start.");
+    });
+  }
+
   function clearChat() {
     chatMessages.innerHTML = "";
     optionsContainer.innerHTML = "";
     optionsContainer.classList.remove("active");
-    state.waitingForSymptoms = true;
+    state.awaitingConsent = true;
+    state.waitingForSymptoms = false;
     state.waitingForSlot = false;
     state.selectedDoctor = null;
     state.selectedSlot = null;
@@ -78,7 +115,7 @@ document.addEventListener("DOMContentLoaded", () => {
     conversation = [{ role: "system", content: basePrompt }];
     updateSummary();
     setTimeout(() => {
-      addBotMessage("Hello! What symptoms are you experiencing today?");
+      showConsentPrompt();
     }, 100);
   }
 
@@ -144,6 +181,18 @@ document.addEventListener("DOMContentLoaded", () => {
     addUserMessage(message);
     userInput.value = "";
 
+    if (message.toLowerCase() === "start") {
+      state.awaitingConsent = true;
+      state.waitingForSymptoms = false;
+      showConsentPrompt();
+      return;
+    }
+
+    if (state.awaitingConsent) {
+      addBotMessage("Please use the buttons above to continue.");
+      return;
+    }
+
     if (state.waitingForSymptoms) {
       try {
         const result = await getRecommendation(message);
@@ -197,5 +246,5 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   updateSummary();
-  addBotMessage("Hello! What symptoms are you experiencing today?");
+  showConsentPrompt();
 });

--- a/script.js
+++ b/script.js
@@ -15,7 +15,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const chatMessages = document.getElementById("chat-messages");
   const userInput = document.getElementById("user-input");
   const sendButton = document.getElementById("send-button");
-  const cameraButton = document.getElementById("camera-button");
   const imageInput = document.getElementById("image-input");
   const clearChatButton = document.getElementById("clear-chat");
   const optionsContainer = document.getElementById("options-container");
@@ -41,6 +40,21 @@ document.addEventListener("DOMContentLoaded", () => {
     const el = document.createElement("div");
     el.className = "message user";
     el.innerHTML = `<div class="message-content">${message}</div>`;
+    chatMessages.appendChild(el);
+    scrollToBottom();
+  }
+
+  function addUserImage(src) {
+    const el = document.createElement("div");
+    el.className = "message user";
+    const content = document.createElement("div");
+    content.className = "message-content";
+    const img = document.createElement("img");
+    img.src = src;
+    img.alt = "uploaded photo";
+    img.style.maxWidth = "160px";
+    content.appendChild(img);
+    el.appendChild(content);
     chatMessages.appendChild(el);
     scrollToBottom();
   }
@@ -104,6 +118,40 @@ document.addEventListener("DOMContentLoaded", () => {
       wrapper.remove();
       state.awaitingConsent = false;
       addBotMessage("No worries. If you change your mind, just type start.");
+    });
+  }
+
+  function showImagePrompt() {
+    addBotMessage("Could you snap a clear photo of the affected area?");
+    document.querySelectorAll('.button-row').forEach((el) => el.remove());
+    const row = document.createElement('div');
+    row.className = 'button-row';
+    const cam = document.createElement('button');
+    cam.className = 'consent-button camera-button';
+    cam.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h3l2-3h8l2 3h3a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>`;
+    const skip = document.createElement('button');
+    skip.className = 'consent-button';
+    skip.textContent = 'Skip';
+    row.appendChild(cam);
+    row.appendChild(skip);
+    chatMessages.appendChild(row);
+    scrollToBottom();
+
+    cam.addEventListener('click', () => {
+      row.remove();
+      imageInput.click();
+    });
+
+    skip.addEventListener('click', () => {
+      row.remove();
+      addUserMessage('Skip');
+      const derm = DOCTORS.find((d) => d.specialty === 'Dermatologist');
+      state.selectedDoctor = derm;
+      state.awaitingImage = false;
+      state.waitingForSymptoms = false;
+      state.waitingForSlot = true;
+      addBotMessage("A dermatologist will give the final word. Let’s book you in!");
+      showAppointmentOptions(state.selectedDoctor);
     });
   }
 
@@ -213,19 +261,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     if (state.awaitingImage) {
-      if (message.toLowerCase() === "skip") {
-        state.awaitingImage = false;
-        const derm = DOCTORS.find((d) => d.specialty === "Dermatologist");
-        state.selectedDoctor = derm;
-        state.waitingForSymptoms = false;
-        state.waitingForSlot = true;
-        addBotMessage(
-          "Looks like eczema — but a dermatologist will give the final word. Let’s book you in!"
-        );
-        showAppointmentOptions(state.selectedDoctor);
-      } else {
-        addBotMessage("Please use the camera button or type skip.");
-      }
+      addBotMessage("Please use the buttons below to upload a photo or skip.");
       return;
     }
 
@@ -234,9 +270,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const dermWords = ["rash", "acne", "mole", "wound", "swelling", "cough"];
       if (dermWords.some((w) => message.toLowerCase().includes(w))) {
         state.awaitingImage = true;
-        addBotMessage(
-          "Could you snap a clear photo of the affected area? You can also type skip if you prefer."
-        );
+        showImagePrompt();
         return;
       }
       try {
@@ -281,6 +315,7 @@ document.addEventListener("DOMContentLoaded", () => {
   async function analyzeImage(file) {
     const reader = new FileReader();
     reader.onload = async () => {
+      addUserImage(reader.result);
       try {
         const messages = [
           {
@@ -333,7 +368,6 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   sendButton.addEventListener("click", handleUserMessage);
-  cameraButton.addEventListener("click", () => imageInput.click());
   imageInput.addEventListener("change", handleImageUpload);
   userInput.addEventListener("keypress", (e) => {
     if (e.key === "Enter") handleUserMessage();

--- a/script.js
+++ b/script.js
@@ -360,18 +360,14 @@ document.addEventListener("DOMContentLoaded", () => {
   function askForLocation() {
     document.querySelectorAll('.button-row').forEach((el) => el.remove());
     const msg = addBotMessage(
-      'May I use your device location to find the nearest clinic?<br>(If you\u2019d rather type your ZIP/postcode, choose Skip.)'
+      'May I use your device location to find the nearest clinic?<br>(If you\u2019d rather type your ZIP/postcode, please enter it below.)'
     );
     const row = document.createElement('div');
     row.className = 'button-row';
     const share = document.createElement('button');
     share.className = 'consent-button';
     share.textContent = 'Share Location \uD83D\uDCCD';
-    const skip = document.createElement('button');
-    skip.className = 'consent-button';
-    skip.textContent = 'Skip \u274C';
     row.appendChild(share);
-    row.appendChild(skip);
     chatMessages.appendChild(row);
     scrollToBottom();
     state.awaitingLocation = true;
@@ -395,14 +391,6 @@ document.addEventListener("DOMContentLoaded", () => {
       );
     });
 
-    skip.addEventListener('click', () => {
-      row.remove();
-      msg.remove();
-      addUserMessage('Skip');
-      state.awaitingLocation = false;
-      state.awaitingZip = true;
-      addBotMessage('Please type your ZIP/postcode.');
-    });
   }
 
   async function fetchClinics(locationText) {
@@ -488,6 +476,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   let clinicMessage = null;
   let doctorMessage = null;
+  let insuranceMessage = null;
+  let paymentMessage = null;
   let clinicsData = [];
   let insuranceOptions = [];
   let expandedDoctorCard = null;
@@ -589,6 +579,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function showDoctorOptions(doctors) {
     if (doctorMessage) doctorMessage.remove();
+    if (paymentMessage) paymentMessage.remove();
     const msg = document.createElement('div');
     msg.className = 'message bot';
     const content = document.createElement('div');
@@ -601,6 +592,7 @@ document.addEventListener("DOMContentLoaded", () => {
     doctors.forEach((d) => {
       const card = document.createElement('div');
       card.className = 'option-card doctor-card';
+      card.__doc = d;
       card.innerHTML =
         `<div><strong>${d.name}</strong> ${d.rating}⭐</div>` +
         `<div class="doctor-desc">${d.desc}</div>` +
@@ -634,7 +626,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function expandDoctorCard(card, doc) {
     if (expandedDoctorCard && expandedDoctorCard !== card) {
-      collapseDoctorCard(expandedDoctorCard);
+      collapseDoctorCard(expandedDoctorCard, expandedDoctorCard.__doc);
     }
     state.selectedDoctor = doc;
     state.awaitingDoctor = false;
@@ -665,6 +657,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function collapseDoctorCard(card, doc) {
+    if (!doc) doc = card.__doc;
     const slots = card.querySelector('.slot-options');
     if (slots) slots.remove();
     const close = card.querySelector('.close-card');
@@ -682,7 +675,8 @@ document.addEventListener("DOMContentLoaded", () => {
   async function askForInsurance() {
     document.querySelectorAll('.button-row').forEach((el) => el.remove());
     insuranceOptions = await fetchInsuranceOptions(state.userLocation || '');
-    addBotMessage(
+    if (insuranceMessage) insuranceMessage.remove();
+    insuranceMessage = addBotMessage(
       `Which insurance will you use? Popular choices here: ${insuranceOptions.slice(0, 3).join(', ')}. Or Other.`
     );
     showInsuranceOptions();
@@ -706,6 +700,7 @@ document.addEventListener("DOMContentLoaded", () => {
     other.textContent = 'Other';
     other.addEventListener('click', () => {
       row.remove();
+      if (insuranceMessage) { insuranceMessage.remove(); insuranceMessage = null; }
       state.awaitingInsurance = false;
       state.awaitingInsuranceOther = true;
       addBotMessage('Please type your insurer name.');
@@ -717,6 +712,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function showPolicyNumberPrompt() {
+    if (insuranceMessage) { insuranceMessage.remove(); insuranceMessage = null; }
     addBotMessage('Please enter your policy number.');
     userInput.placeholder = 'Policy number';
     state.awaitingPolicy = true;
@@ -798,6 +794,7 @@ document.addEventListener("DOMContentLoaded", () => {
   function selectInsurance(name) {
     state.selectedInsurance = name;
     state.awaitingInsurance = false;
+    if (insuranceMessage) { insuranceMessage.remove(); insuranceMessage = null; }
     showPolicyNumberPrompt();
   }
 
@@ -835,10 +832,12 @@ document.addEventListener("DOMContentLoaded", () => {
     msg.appendChild(content);
     chatMessages.appendChild(msg);
     scrollToBottom();
+    paymentMessage = msg;
     state.awaitingPayment = true;
 
     pay.addEventListener('click', () => {
       state.awaitingPayment = false;
+      if (paymentMessage) { paymentMessage.remove(); paymentMessage = null; }
       showContactForm();
     });
   }
@@ -960,7 +959,14 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     if (state.awaitingLocation) {
-      addBotMessage('Please use the buttons below to share your location or skip.');
+      state.awaitingLocation = false;
+      if (message.toLowerCase() === 'skip') {
+        state.awaitingZip = true;
+        addBotMessage('Please type your ZIP/postcode.');
+      } else {
+        state.userLocation = message;
+        fetchClinics(message);
+      }
       return;
     }
 

--- a/script.js
+++ b/script.js
@@ -48,6 +48,10 @@ document.addEventListener("DOMContentLoaded", () => {
     clarifying: false,
     clarifyIndex: 0,
     clarifyAnswers: [],
+    awaitingCoverageConfirm: false,
+    awaitingPayment: false,
+    awaitingContact: false,
+    priceEstimate: "",
   };
 
   const bookings = [];
@@ -772,14 +776,122 @@ document.addEventListener("DOMContentLoaded", () => {
     const stop = showCheckingCoverage();
     const price = await fetchConsultationPrice(state.userLocation || 'your area', state.selectedInsurance || 'your insurance');
     stop();
-    addBotMessage(`Your consultation is estimated at ${price} (${state.selectedInsurance} negotiated rate). <span class="subtle-text">This covers the visit only; treatment costs may vary.</span>`);
-    finalizeBooking();
+    state.priceEstimate = price;
+    const msg = addBotMessage(`Your consultation is estimated at ${price} (${state.selectedInsurance} negotiated rate).<br><span class="subtle-text">This covers the visit only; treatment costs may vary.</span>`);
+    const row = document.createElement('div');
+    row.className = 'button-row';
+    const confirm = document.createElement('button');
+    confirm.className = 'consent-button';
+    confirm.textContent = 'Confirm';
+    row.appendChild(confirm);
+    chatMessages.appendChild(row);
+    scrollToBottom();
+    state.awaitingCoverageConfirm = true;
+
+    confirm.addEventListener('click', () => {
+      row.remove();
+      state.awaitingCoverageConfirm = false;
+      showPaymentDetails();
+    });
   }
 
   function selectInsurance(name) {
     state.selectedInsurance = name;
     state.awaitingInsurance = false;
     showPolicyNumberPrompt();
+  }
+
+  function showPaymentDetails() {
+    const msg = document.createElement('div');
+    msg.className = 'message bot';
+    const content = document.createElement('div');
+    content.className = 'message-content';
+    const form = document.createElement('div');
+    form.className = 'payment-form';
+    form.innerHTML = `
+      <div class="form-group">
+        <label>Card Number</label>
+        <input class="form-input" value="4111 1111 1111 1111">
+      </div>
+      <div class="form-row">
+        <div class="form-group">
+          <label>Expiry</label>
+          <input class="form-input" value="12/25">
+        </div>
+        <div class="form-group">
+          <label>CVC</label>
+          <input class="form-input" value="123">
+        </div>
+      </div>
+    `;
+    const actions = document.createElement('div');
+    actions.className = 'payment-actions';
+    const pay = document.createElement('button');
+    pay.className = 'glass-button primary';
+    pay.textContent = 'Pay';
+    actions.appendChild(pay);
+    form.appendChild(actions);
+    content.appendChild(form);
+    msg.appendChild(content);
+    chatMessages.appendChild(msg);
+    scrollToBottom();
+    state.awaitingPayment = true;
+
+    pay.addEventListener('click', () => {
+      state.awaitingPayment = false;
+      showContactForm();
+    });
+  }
+
+  function showContactForm() {
+    const msg = document.createElement('div');
+    msg.className = 'message bot';
+    const content = document.createElement('div');
+    content.className = 'message-content';
+    const form = document.createElement('div');
+    form.className = 'payment-form';
+    form.innerHTML = `
+      <div class="form-group">
+        <label>Name</label>
+        <input id="contact-name" class="form-input" value="${state.name}">
+      </div>
+      <div class="form-group">
+        <label>Phone</label>
+        <div class="form-row">
+          <select id="contact-country" class="form-input" style="flex:0.5">
+            <option value="+1">+1</option>
+            <option value="+44">+44</option>
+            <option value="+61">+61</option>
+            <option value="+34">+34</option>
+          </select>
+          <input id="contact-phone" class="form-input" value="">
+        </div>
+      </div>
+      <div class="form-group">
+        <label>Email</label>
+        <input id="contact-email" class="form-input" type="email">
+      </div>
+      <div class="form-group">
+        <label><input type="checkbox" id="contact-ok" checked> Send updates to these contacts</label>
+      </div>
+    `;
+    const actions = document.createElement('div');
+    actions.className = 'payment-actions';
+    const confirm = document.createElement('button');
+    confirm.className = 'glass-button primary';
+    confirm.textContent = 'Confirm';
+    actions.appendChild(confirm);
+    form.appendChild(actions);
+    content.appendChild(form);
+    msg.appendChild(content);
+    chatMessages.appendChild(msg);
+    scrollToBottom();
+    state.awaitingContact = true;
+
+    confirm.addEventListener('click', () => {
+      state.awaitingContact = false;
+      finalizeBooking();
+    });
   }
 
   function finalizeBooking() {
@@ -799,10 +911,14 @@ document.addEventListener("DOMContentLoaded", () => {
     state.selectedSlot = null;
     state.selectedInsurance = '';
     state.policyNumber = '';
+    state.priceEstimate = '';
     state.aiQuestions = 0;
     state.clarifying = false;
     state.clarifyIndex = 0;
     state.clarifyAnswers = [];
+    state.awaitingCoverageConfirm = false;
+    state.awaitingPayment = false;
+    state.awaitingContact = false;
     conversation = [{ role: 'system', content: basePrompt }];
     userInput.placeholder = DEFAULT_PLACEHOLDER;
     setTimeout(() => {
@@ -875,6 +991,21 @@ document.addEventListener("DOMContentLoaded", () => {
       state.awaitingPolicy = false;
       userInput.placeholder = DEFAULT_PLACEHOLDER;
       checkCoverage();
+      return;
+    }
+
+    if (state.awaitingCoverageConfirm) {
+      addBotMessage('Please use the Confirm button below.');
+      return;
+    }
+
+    if (state.awaitingPayment) {
+      addBotMessage('Please use the Pay button below.');
+      return;
+    }
+
+    if (state.awaitingContact) {
+      addBotMessage('Please fill the form and press Confirm.');
       return;
     }
 

--- a/script.js
+++ b/script.js
@@ -306,6 +306,37 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+  async function checkNeedPhoto(text) {
+    const messages = [
+      {
+        role: "user",
+        content:
+          `A patient says: ${text}. Do these symptoms require a photo for better assessment? Reply ONLY with JSON {"photo":true|false}.`,
+      },
+    ];
+    try {
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "gpt-3.5-turbo", messages }),
+      });
+      const data = await response.json();
+      if (response.ok) {
+        let content = data.choices?.[0]?.message?.content?.trim();
+        if (content) {
+          content = content.replace(/```json|```/g, "").trim();
+          try {
+            const parsed = JSON.parse(content);
+            return !!parsed.photo;
+          } catch {}
+        }
+      }
+    } catch (err) {
+      console.error(err);
+    }
+    return false;
+  }
+
   function askForLocation() {
     document.querySelectorAll('.button-row').forEach((el) => el.remove());
     addBotMessage(
@@ -530,14 +561,18 @@ document.addEventListener("DOMContentLoaded", () => {
       return;
     }
 
-    if (state.waitingForSymptoms) {
-      state.lastSymptom = message;
-      const dermWords = ["rash", "acne", "mole", "wound", "swelling", "cough"];
-      if (dermWords.some((w) => message.toLowerCase().includes(w))) {
-        state.awaitingImage = true;
-        showImagePrompt();
-        return;
-      }
+      if (state.waitingForSymptoms) {
+        state.lastSymptom = message;
+        const dermWords = ["rash", "acne", "mole", "wound", "swelling", "cough"];
+        let needsPhoto = false;
+        try {
+          needsPhoto = await checkNeedPhoto(message);
+        } catch {}
+        if (needsPhoto || dermWords.some((w) => message.toLowerCase().includes(w))) {
+          state.awaitingImage = true;
+          showImagePrompt();
+          return;
+        }
       try {
         const result = await getRecommendation(message);
         if (result.question && state.aiQuestions < 3) {

--- a/script.js
+++ b/script.js
@@ -478,6 +478,7 @@ document.addEventListener("DOMContentLoaded", () => {
   let doctorMessage = null;
   let insuranceMessage = null;
   let paymentMessage = null;
+  let contactMessage = null;
   let clinicsData = [];
   let insuranceOptions = [];
   let expandedDoctorCard = null;
@@ -561,21 +562,24 @@ document.addEventListener("DOMContentLoaded", () => {
           rating: (4 + Math.random()).toFixed(1),
           languages: ['English'],
           slots: d.slots,
+          specialty: spec,
         })).slice(0, 4);
       }
+      docs = docs.map((d) => ({ ...d, specialty: spec }));
       showDoctorOptions(docs);
-    } catch (err) {
-      console.error(err);
-      const docs = DOCTORS.filter((d) => d.specialty === spec).map((d) => ({
-        name: d.name,
-        desc: `${spec} with 5 years experience`,
-        rating: (4 + Math.random()).toFixed(1),
-        languages: ['English'],
-        slots: d.slots,
-      })).slice(0, 4);
-      showDoctorOptions(docs);
-    }
+  } catch (err) {
+    console.error(err);
+    const docs = DOCTORS.filter((d) => d.specialty === spec).map((d) => ({
+      name: d.name,
+      desc: `${spec} with 5 years experience`,
+      rating: (4 + Math.random()).toFixed(1),
+      languages: ['English'],
+      slots: d.slots,
+      specialty: spec,
+    })).slice(0, 4);
+    showDoctorOptions(docs);
   }
+}
 
   function showDoctorOptions(doctors) {
     if (doctorMessage) doctorMessage.remove();
@@ -885,10 +889,12 @@ document.addEventListener("DOMContentLoaded", () => {
     msg.appendChild(content);
     chatMessages.appendChild(msg);
     scrollToBottom();
+    contactMessage = msg;
     state.awaitingContact = true;
 
     confirm.addEventListener('click', () => {
       state.awaitingContact = false;
+      if (contactMessage) { contactMessage.remove(); contactMessage = null; }
       finalizeBooking();
     });
   }
@@ -921,7 +927,7 @@ document.addEventListener("DOMContentLoaded", () => {
     conversation = [{ role: 'system', content: basePrompt }];
     userInput.placeholder = DEFAULT_PLACEHOLDER;
     setTimeout(() => {
-      addBotMessage('Let me know if you have other symptoms.');
+      addBotMessage('Let me know if you want to make another booking.');
     }, 100);
   }
 

--- a/script.js
+++ b/script.js
@@ -1,5 +1,4 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const API_KEY = ""; // Set your OpenAI API key here
 
   const DOCTORS = [
     { name: "Dr. Adams", specialty: "Cardiologist", slots: ["10:00 tomorrow", "15:00 tomorrow", "10:00 next Monday"] },
@@ -84,21 +83,17 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   async function getRecommendation(text) {
-    if (!API_KEY) {
-      throw new Error("OpenAI API key not set");
-    }
     conversation.push({ role: "user", content: text });
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch("/api/chat", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${API_KEY}`,
       },
       body: JSON.stringify({ model: "gpt-3.5-turbo", messages: conversation }),
     });
     const data = await response.json();
     if (!response.ok) {
-      throw new Error(data.error?.message || "API request failed");
+      throw new Error(data.error || "API request failed");
     }
     const reply = data.choices[0].message.content.trim();
     conversation.push({ role: "assistant", content: reply });

--- a/script.js
+++ b/script.js
@@ -345,7 +345,8 @@ document.addEventListener("DOMContentLoaded", () => {
               {
                 type: "text",
                 text:
-                  "Assess this skin photo and return JSON like {\"diff\":[\"Diag1\",\"Diag2\",\"Diag3\"]}.",
+                  `A patient describes: ${state.lastSymptom}. ` +
+                  "Assess this skin photo and respond ONLY with JSON {\"diff\": [\"Diag1\", \"Diag2\", \"Diag3\"]}.",
               },
               { type: "image_url", image_url: { url: reader.result } },
             ],
@@ -357,11 +358,19 @@ document.addEventListener("DOMContentLoaded", () => {
           body: JSON.stringify({ model: "gpt-4o", messages }),
         });
         const data = await response.json();
-        let diag = "eczema";
+        let diag = "unsure";
         if (response.ok) {
-          try {
-            diag = JSON.parse(data.choices[0].message.content.trim()).diff[0];
-          } catch {}
+          const content = data.choices?.[0]?.message?.content?.trim();
+          if (content) {
+            try {
+              const parsed = JSON.parse(content);
+              if (Array.isArray(parsed.diff) && parsed.diff.length) {
+                diag = parsed.diff[0];
+              }
+            } catch {
+              diag = content.split(/[\.\n]/)[0];
+            }
+          }
         }
         stopLoading();
         state.awaitingImage = false;

--- a/script.js
+++ b/script.js
@@ -392,28 +392,40 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+  function pluralSpecialty(spec) {
+    return spec.endsWith('s') ? spec : spec + 's';
+  }
+
   function showClinicOptions(clinics) {
-    optionsContainer.innerHTML = '';
-    const header = document.createElement('div');
-    header.className = 'options-header';
-    header.innerHTML = '<h3>Here are some options:</h3>';
-    const grid = document.createElement('div');
-    grid.className = 'options-grid';
+    const message = document.createElement('div');
+    message.className = 'message bot';
+    const content = document.createElement('div');
+    content.className = 'message-content';
+    const intro = document.createElement('p');
+    intro.textContent = 'Here are three options:';
+    const container = document.createElement('div');
+    container.className = 'clinic-options';
+
     clinics.forEach((c) => {
       const card = document.createElement('div');
-      card.className = 'option-card';
-      card.innerHTML = `<div class="option-header"><span>${c.name}</span><span>${c.distance} km</span></div>` +
-        `<div>${c.address} - ${c.rating}⭐ - ${state.selectedDoctor.specialty} available in ${c.days} days</div>`;
+      card.className = 'option-card clinic-card';
+      card.innerHTML =
+        `<div><strong>${c.name}</strong> ${c.rating}⭐ – ${c.distance} km away</div>` +
+        `<div class="clinic-address">${c.address}</div>` +
+        `<div>${pluralSpecialty(state.selectedDoctor.specialty)} available in ${c.days} days</div>`;
       const btn = document.createElement('button');
       btn.className = 'glass-button select-clinic';
       btn.textContent = 'Book Appointment';
       btn.addEventListener('click', () => selectClinic(c));
       card.appendChild(btn);
-      grid.appendChild(card);
+      container.appendChild(card);
     });
-    optionsContainer.appendChild(header);
-    optionsContainer.appendChild(grid);
-    optionsContainer.classList.add('active');
+
+    content.appendChild(intro);
+    content.appendChild(container);
+    message.appendChild(content);
+    chatMessages.appendChild(message);
+    scrollToBottom();
     state.awaitingClinic = true;
   }
 

--- a/script.js
+++ b/script.js
@@ -21,6 +21,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const summary = document.getElementById("booking-summary");
   const appointmentTemplate = document.getElementById("appointment-options-template");
 
+  const DEFAULT_PLACEHOLDER = userInput.placeholder;
+
   const state = {
     awaitingConsent: true,
     awaitingName: false,
@@ -36,11 +38,13 @@ document.addEventListener("DOMContentLoaded", () => {
     awaitingDoctor: false,
     awaitingInsurance: false,
     awaitingInsuranceOther: false,
+    awaitingPolicy: false,
     aiQuestions: 0,
     name: "",
     lastSymptom: "",
     userLocation: "",
     selectedInsurance: "",
+    policyNumber: "",
     clarifying: false,
     clarifyIndex: 0,
     clarifyAnswers: [],
@@ -676,10 +680,74 @@ document.addEventListener("DOMContentLoaded", () => {
     state.awaitingInsurance = true;
   }
 
+  function showPolicyNumberPrompt() {
+    addBotMessage('Please enter your policy number.');
+    userInput.placeholder = 'Policy number';
+    state.awaitingPolicy = true;
+  }
+
+  function showCheckingCoverage() {
+    const el = document.createElement('div');
+    el.className = 'message bot';
+    const content = document.createElement('div');
+    content.className = 'message-content';
+    content.textContent = 'Checking coverage';
+    el.appendChild(content);
+    chatMessages.appendChild(el);
+    scrollToBottom();
+    let dots = 0;
+    const interval = setInterval(() => {
+      dots = (dots + 1) % 4;
+      content.textContent = 'Checking coverage' + '.'.repeat(dots);
+    }, 500);
+    return () => {
+      clearInterval(interval);
+      el.remove();
+    };
+  }
+
+  async function fetchConsultationPrice(loc, insurance) {
+    const messages = [
+      {
+        role: 'user',
+        content: `In ${loc}, what is an approximate dermatologist consultation price with ${insurance} insurance? Respond ONLY with JSON {"price":"amount CUR"}`,
+      },
+    ];
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-3.5-turbo', messages }),
+      });
+      const data = await response.json();
+      if (response.ok) {
+        let content = data.choices?.[0]?.message?.content?.trim();
+        if (content) {
+          content = content.replace(/```json|```/g, '').trim();
+          try {
+            const parsed = JSON.parse(content);
+            if (parsed.price) return parsed.price;
+          } catch {}
+        }
+      }
+    } catch (err) {
+      console.error(err);
+    }
+    return '50 USD';
+  }
+
+  async function checkCoverage() {
+    const stop = showCheckingCoverage();
+    const price = await fetchConsultationPrice(state.userLocation || 'your area', state.selectedInsurance || 'your insurance');
+    stop();
+    addBotMessage(`Your consultation is estimated at ${price} (${state.selectedInsurance} negotiated rate). <span class="subtle-text">This covers the visit only; treatment costs may vary.</span>`);
+    finalizeBooking();
+  }
+
   function selectInsurance(name) {
     state.selectedInsurance = name;
     state.awaitingInsurance = false;
-    finalizeBooking();
+    showPolicyNumberPrompt();
   }
 
   function finalizeBooking() {
@@ -698,11 +766,13 @@ document.addEventListener("DOMContentLoaded", () => {
     state.selectedDoctor = null;
     state.selectedSlot = null;
     state.selectedInsurance = '';
+    state.policyNumber = '';
     state.aiQuestions = 0;
     state.clarifying = false;
     state.clarifyIndex = 0;
     state.clarifyAnswers = [];
     conversation = [{ role: 'system', content: basePrompt }];
+    userInput.placeholder = DEFAULT_PLACEHOLDER;
     setTimeout(() => {
       addBotMessage('Let me know if you have other symptoms.');
     }, 100);
@@ -764,10 +834,18 @@ document.addEventListener("DOMContentLoaded", () => {
       return;
     }
 
+    if (state.awaitingPolicy) {
+      state.policyNumber = message;
+      state.awaitingPolicy = false;
+      userInput.placeholder = DEFAULT_PLACEHOLDER;
+      checkCoverage();
+      return;
+    }
+
     if (state.awaitingInsuranceOther) {
       state.selectedInsurance = message;
       state.awaitingInsuranceOther = false;
-      finalizeBooking();
+      showPolicyNumberPrompt();
       return;
     }
 

--- a/script.js
+++ b/script.js
@@ -67,6 +67,26 @@ document.addEventListener("DOMContentLoaded", () => {
     scrollToBottom();
   }
 
+  function showAnalyzing() {
+    const el = document.createElement("div");
+    el.className = "message bot";
+    const content = document.createElement("div");
+    content.className = "message-content";
+    content.textContent = "Analyzing";
+    el.appendChild(content);
+    chatMessages.appendChild(el);
+    scrollToBottom();
+    let dots = 0;
+    const interval = setInterval(() => {
+      dots = (dots + 1) % 4;
+      content.textContent = "Analyzing" + ".".repeat(dots);
+    }, 500);
+    return () => {
+      clearInterval(interval);
+      el.remove();
+    };
+  }
+
   function scrollToBottom() {
     chatMessages.scrollTop = chatMessages.scrollHeight;
   }
@@ -316,6 +336,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const reader = new FileReader();
     reader.onload = async () => {
       addUserImage(reader.result);
+      const stopLoading = showAnalyzing();
       try {
         const messages = [
           {
@@ -342,6 +363,7 @@ document.addEventListener("DOMContentLoaded", () => {
             diag = JSON.parse(data.choices[0].message.content.trim()).diff[0];
           } catch {}
         }
+        stopLoading();
         state.awaitingImage = false;
         const derm = DOCTORS.find((d) => d.specialty === "Dermatologist");
         state.selectedDoctor = derm;
@@ -353,6 +375,7 @@ document.addEventListener("DOMContentLoaded", () => {
         showAppointmentOptions(state.selectedDoctor);
       } catch (err) {
         console.error(err);
+        stopLoading();
         state.awaitingImage = false;
         addBotMessage(
           "Error analyzing image. We'll book you with a dermatologist to be safe."

--- a/script.js
+++ b/script.js
@@ -29,6 +29,8 @@ document.addEventListener("DOMContentLoaded", () => {
     aiQuestions: 0,
   };
 
+  const bookings = [];
+
   function addUserMessage(message) {
     const el = document.createElement("div");
     el.className = "message user";
@@ -51,18 +53,18 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function updateSummary() {
     summary.innerHTML = "<h3>Your Appointments</h3>";
-    if (state.selectedDoctor && state.selectedSlot) {
-      const div = document.createElement("div");
-      div.className = "summary-content";
-      div.innerHTML = `<p><strong>${state.selectedDoctor.name}</strong> (${state.selectedDoctor.specialty})</p>` +
-        `<p>${state.selectedSlot}</p>`;
-      summary.appendChild(div);
+    const div = document.createElement("div");
+    div.className = "summary-content";
+    if (bookings.length) {
+      bookings.forEach((b) => {
+        const p = document.createElement("p");
+        p.innerHTML = `<strong>${b.doctor.name}</strong> (${b.doctor.specialty}) - ${b.slot}`;
+        div.appendChild(p);
+      });
     } else {
-      const div = document.createElement("div");
-      div.className = "summary-content";
       div.innerHTML = "<p>No appointment yet</p>";
-      summary.appendChild(div);
     }
+    summary.appendChild(div);
   }
 
   function clearChat() {
@@ -125,11 +127,20 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function selectSlot(time) {
+    bookings.push({ doctor: state.selectedDoctor, slot: time });
     state.selectedSlot = time;
     state.waitingForSlot = false;
     optionsContainer.classList.remove("active");
     addBotMessage(`Appointment with ${state.selectedDoctor.name} confirmed for ${time}. You'll receive a reminder!`);
     updateSummary();
+    state.waitingForSymptoms = true;
+    state.selectedDoctor = null;
+    state.selectedSlot = null;
+    state.aiQuestions = 0;
+    conversation = [{ role: "system", content: basePrompt }];
+    setTimeout(() => {
+      addBotMessage("Let me know if you have other symptoms.");
+    }, 100);
   }
 
   async function handleUserMessage() {

--- a/script.js
+++ b/script.js
@@ -29,6 +29,10 @@ document.addEventListener("DOMContentLoaded", () => {
     waitingForSlot: false,
     selectedDoctor: null,
     selectedSlot: null,
+    selectedClinic: null,
+    awaitingLocation: false,
+    awaitingZip: false,
+    awaitingClinic: false,
     aiQuestions: 0,
     name: "",
     lastSymptom: "",
@@ -107,7 +111,8 @@ document.addEventListener("DOMContentLoaded", () => {
     if (bookings.length) {
       bookings.forEach((b) => {
         const p = document.createElement("p");
-        p.innerHTML = `<strong>${b.doctor.name}</strong> (${b.doctor.specialty}) - ${b.slot}`;
+        const clinicText = b.clinic ? ` at ${b.clinic.name}` : "";
+        p.innerHTML = `<strong>${b.doctor.name}</strong> (${b.doctor.specialty})${clinicText} - ${b.slot}`;
         div.appendChild(p);
       });
     } else {
@@ -202,21 +207,19 @@ document.addEventListener("DOMContentLoaded", () => {
       const derm = DOCTORS.find((d) => d.specialty === 'Dermatologist');
       state.selectedDoctor = derm;
       state.waitingForSymptoms = false;
-      state.waitingForSlot = true;
       addBotMessage(
         `Looks like ${diag} \u2014 but a dermatologist will give the final word. Let\u2019s book you in!`
       );
-      showAppointmentOptions(state.selectedDoctor);
+      askForLocation();
     } catch (err) {
       console.error(err);
       const derm = DOCTORS.find((d) => d.specialty === 'Dermatologist');
       state.selectedDoctor = derm;
       state.waitingForSymptoms = false;
-      state.waitingForSlot = true;
       addBotMessage(
         "A dermatologist will give the final word. Let’s book you in!"
       );
-      showAppointmentOptions(state.selectedDoctor);
+      askForLocation();
     }
   }
 
@@ -262,8 +265,12 @@ document.addEventListener("DOMContentLoaded", () => {
     state.awaitingImage = false;
     state.waitingForSymptoms = false;
     state.waitingForSlot = false;
+    state.awaitingLocation = false;
+    state.awaitingZip = false;
+    state.awaitingClinic = false;
     state.selectedDoctor = null;
     state.selectedSlot = null;
+    state.selectedClinic = null;
     state.aiQuestions = 0;
     state.name = "";
     state.lastSymptom = "";
@@ -299,6 +306,124 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+  function askForLocation() {
+    document.querySelectorAll('.button-row').forEach((el) => el.remove());
+    addBotMessage(
+      'May I use your device location to find the nearest clinic?<br>(If you\u2019d rather type your ZIP/postcode, choose Skip.)'
+    );
+    const row = document.createElement('div');
+    row.className = 'button-row';
+    const share = document.createElement('button');
+    share.className = 'consent-button';
+    share.textContent = 'Share Location \uD83D\uDCCD';
+    const skip = document.createElement('button');
+    skip.className = 'consent-button';
+    skip.textContent = 'Skip \u274C';
+    row.appendChild(share);
+    row.appendChild(skip);
+    chatMessages.appendChild(row);
+    scrollToBottom();
+    state.awaitingLocation = true;
+
+    share.addEventListener('click', () => {
+      row.remove();
+      state.awaitingLocation = false;
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const loc = `${pos.coords.latitude.toFixed(3)},${pos.coords.longitude.toFixed(3)}`;
+          fetchClinics(loc);
+        },
+        () => {
+          addBotMessage("Couldn't get your location. Please type your ZIP/postcode.");
+          state.awaitingZip = true;
+        }
+      );
+    });
+
+    skip.addEventListener('click', () => {
+      row.remove();
+      addUserMessage('Skip');
+      state.awaitingLocation = false;
+      state.awaitingZip = true;
+      addBotMessage('Please type your ZIP/postcode.');
+    });
+  }
+
+  async function fetchClinics(locationText) {
+    const messages = [
+      {
+        role: 'user',
+        content:
+          `Generate 3 fictional clinic options near ${locationText} with distance in km, address, rating out of 5, and days until a ${state.selectedDoctor.specialty} is available. Respond ONLY with JSON [{"name":"","distance":0,"address":"","rating":0,"days":0}]`,
+      },
+    ];
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-3.5-turbo', messages }),
+      });
+      const data = await response.json();
+      let clinics = [];
+      if (response.ok) {
+        let content = data.choices?.[0]?.message?.content?.trim();
+        if (content) {
+          content = content.replace(/```json|```/g, '').trim();
+          try {
+            clinics = JSON.parse(content);
+          } catch {}
+        }
+      }
+      if (!Array.isArray(clinics) || !clinics.length) {
+        clinics = [
+          { name: 'HealthCo Central', distance: 2, address: '1 Main St', rating: 4.6, days: 2 },
+          { name: 'Downtown Clinic', distance: 5, address: '55 Oak Ave', rating: 4.4, days: 3 },
+          { name: 'Riverside Health', distance: 7, address: '200 River Rd', rating: 4.2, days: 4 },
+        ];
+      }
+      showClinicOptions(clinics);
+    } catch (err) {
+      console.error(err);
+      showClinicOptions([
+        { name: 'HealthCo Central', distance: 2, address: '1 Main St', rating: 4.6, days: 2 },
+        { name: 'Downtown Clinic', distance: 5, address: '55 Oak Ave', rating: 4.4, days: 3 },
+        { name: 'Riverside Health', distance: 7, address: '200 River Rd', rating: 4.2, days: 4 },
+      ]);
+    }
+  }
+
+  function showClinicOptions(clinics) {
+    optionsContainer.innerHTML = '';
+    const header = document.createElement('div');
+    header.className = 'options-header';
+    header.innerHTML = '<h3>Here are some options:</h3>';
+    const grid = document.createElement('div');
+    grid.className = 'options-grid';
+    clinics.forEach((c) => {
+      const card = document.createElement('div');
+      card.className = 'option-card';
+      card.innerHTML = `<div class="option-header"><span>${c.name}</span><span>${c.distance} km</span></div>` +
+        `<div>${c.address} - ${c.rating}⭐ - ${state.selectedDoctor.specialty} available in ${c.days} days</div>`;
+      const btn = document.createElement('button');
+      btn.className = 'glass-button select-clinic';
+      btn.textContent = 'Book Appointment';
+      btn.addEventListener('click', () => selectClinic(c));
+      card.appendChild(btn);
+      grid.appendChild(card);
+    });
+    optionsContainer.appendChild(header);
+    optionsContainer.appendChild(grid);
+    optionsContainer.classList.add('active');
+    state.awaitingClinic = true;
+  }
+
+  function selectClinic(clinic) {
+    state.selectedClinic = clinic;
+    state.awaitingClinic = false;
+    optionsContainer.classList.remove('active');
+    showAppointmentOptions(state.selectedDoctor);
+  }
+
   function showAppointmentOptions(doctor) {
     optionsContainer.innerHTML = "";
     if (!appointmentTemplate) return;
@@ -314,16 +439,18 @@ document.addEventListener("DOMContentLoaded", () => {
     });
     optionsContainer.appendChild(content);
     optionsContainer.classList.add("active");
+    state.waitingForSlot = true;
   }
 
   function selectSlot(time) {
-    bookings.push({ doctor: state.selectedDoctor, slot: time });
+    bookings.push({ doctor: state.selectedDoctor, clinic: state.selectedClinic, slot: time });
     state.selectedSlot = time;
     state.waitingForSlot = false;
     optionsContainer.classList.remove("active");
     addBotMessage(`Appointment with ${state.selectedDoctor.name} confirmed for ${time}. You'll receive a reminder!`);
     updateSummary();
     state.waitingForSymptoms = true;
+    state.selectedClinic = null;
     state.selectedDoctor = null;
     state.selectedSlot = null;
     state.aiQuestions = 0;
@@ -353,6 +480,22 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (state.awaitingConsent) {
       addBotMessage("Please use the buttons below to continue.");
+      return;
+    }
+
+    if (state.awaitingLocation) {
+      addBotMessage('Please use the buttons below to share your location or skip.');
+      return;
+    }
+
+    if (state.awaitingZip) {
+      state.awaitingZip = false;
+      fetchClinics(message);
+      return;
+    }
+
+    if (state.awaitingClinic) {
+      addBotMessage('Please choose one of the clinic options below.');
       return;
     }
 
@@ -395,9 +538,8 @@ document.addEventListener("DOMContentLoaded", () => {
             slots: result.slots,
           };
           state.waitingForSymptoms = false;
-          state.waitingForSlot = true;
-          addBotMessage(`You may need a consultation with a ${state.selectedDoctor.specialty}. Available times:`);
-          showAppointmentOptions(state.selectedDoctor);
+          addBotMessage(`You may need a consultation with a ${state.selectedDoctor.specialty}.`);
+          askForLocation();
         } else {
           addBotMessage("Sorry, I couldn't understand. Could you rephrase?");
         }
@@ -476,12 +618,11 @@ document.addEventListener("DOMContentLoaded", () => {
         const derm = DOCTORS.find((d) => d.specialty === "Dermatologist");
         state.selectedDoctor = derm;
         state.waitingForSymptoms = false;
-        state.waitingForSlot = true;
         const messageDesc = desc ? `${desc} ` : "";
         addBotMessage(
           `${messageDesc}Looks like ${diag} \u2014 but a dermatologist will give the final word. Let\u2019s book you in!`
         );
-        showAppointmentOptions(state.selectedDoctor);
+        askForLocation();
       } catch (err) {
         console.error(err);
         stopLoading();
@@ -492,8 +633,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const derm = DOCTORS.find((d) => d.specialty === "Dermatologist");
         state.selectedDoctor = derm;
         state.waitingForSymptoms = false;
-        state.waitingForSlot = true;
-        showAppointmentOptions(state.selectedDoctor);
+        askForLocation();
       }
     };
     reader.readAsDataURL(file);

--- a/styles.css
+++ b/styles.css
@@ -216,6 +216,11 @@ body::after {
   line-height: 1.5;
 }
 
+.message-content img {
+  max-width: 160px;
+  border-radius: 8px;
+}
+
 .button-row {
   display: flex;
   gap: 10px;

--- a/styles.css
+++ b/styles.css
@@ -216,6 +216,26 @@ body::after {
   line-height: 1.5;
 }
 
+.button-row {
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.consent-button {
+  background: #fff;
+  border: 1px solid #000;
+  border-radius: 8px;
+  padding: 8px 14px;
+  color: #000;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.consent-button:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
 .chat-input-container {
   display: flex;
   gap: 10px;

--- a/styles.css
+++ b/styles.css
@@ -284,12 +284,11 @@ body::after {
 }
 
 .camera-button {
-  background: var(--primary-light);
   margin-right: 8px;
 }
 
 .camera-button:hover {
-  background: var(--primary-color);
+  background: rgba(0, 0, 0, 0.05);
 }
 
 /* Options Container Styling */

--- a/styles.css
+++ b/styles.css
@@ -238,6 +238,22 @@ body::after {
   color: #555;
 }
 
+.doctor-options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.doctor-desc {
+  font-size: 0.9rem;
+}
+
+.doctor-lang {
+  color: #555;
+  font-size: 0.85rem;
+}
+
 .consent-button {
   background: #fff;
   border: 1px solid #000;

--- a/styles.css
+++ b/styles.css
@@ -278,6 +278,15 @@ body::after {
   transform: scale(1.05);
 }
 
+.camera-button {
+  background: var(--primary-light);
+  margin-right: 8px;
+}
+
+.camera-button:hover {
+  background: var(--primary-color);
+}
+
 /* Options Container Styling */
 .options-container {
   height: 0;

--- a/styles.css
+++ b/styles.css
@@ -331,6 +331,10 @@ body::after {
   background: rgba(0, 0, 0, 0.05);
 }
 
+.subtle-text {
+  color: #555;
+}
+
 /* Options Container Styling */
 .options-container {
   height: 0;

--- a/styles.css
+++ b/styles.css
@@ -254,6 +254,19 @@ body::after {
   font-size: 0.85rem;
 }
 
+.slot-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.slot-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .consent-button {
   background: #fff;
   border: 1px solid #000;

--- a/styles.css
+++ b/styles.css
@@ -335,6 +335,22 @@ body::after {
   color: #555;
 }
 
+.back-button {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  margin-bottom: 4px;
+}
+
+.close-card {
+  background: none;
+  border: none;
+  font-size: 1rem;
+  align-self: flex-end;
+  cursor: pointer;
+}
+
 /* Options Container Styling */
 .options-container {
   height: 0;

--- a/styles.css
+++ b/styles.css
@@ -227,6 +227,17 @@ body::after {
   margin-top: 6px;
 }
 
+.clinic-options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.clinic-address {
+  color: #555;
+}
+
 .consent-button {
   background: #fff;
   border: 1px solid #000;


### PR DESCRIPTION
## Summary
- track booked appointments in an array
- show all appointments in the summary panel
- reset the AI conversation after an appointment so the user can book again

## Testing
- `node -v`
- `curl -I https://api.openai.com/v1/models | head`

------
https://chatgpt.com/codex/tasks/task_e_6852b9c1244883228922c9e0ca8eaec2